### PR TITLE
Specified utf-8 encoding because backward quotes used.

### DIFF
--- a/pyopenscope/openscope/openscope.py
+++ b/pyopenscope/openscope/openscope.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 class OpenScope:
     """
     Library designed to communicate with the OpenScope


### PR DESCRIPTION
Without this I get SyntaxError: Non-ASCII character '\xe2' in file d:\chris\projects\repraptor\pyopenscope\pyopenscope\openscope\openscope.py on line 173, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details